### PR TITLE
chore: Restrict verify function to a view

### DIFF
--- a/src/interfaces/IVerifier.sol
+++ b/src/interfaces/IVerifier.sol
@@ -4,5 +4,4 @@ pragma solidity >=0.8.4;
 
 interface IVerifier {
     function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external view returns (bool);
-    function verify(bytes calldata _proofData) external view returns (bool);
 }

--- a/src/standard/BaseStandardVerifier.sol
+++ b/src/standard/BaseStandardVerifier.sol
@@ -155,7 +155,7 @@ abstract contract BaseStandardVerifier {
      * @param _publicInputs - An array of the public inputs
      * @return True if proof is valid, reverts otherwise
      */
-    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external returns (bool) {
+    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external view returns (bool) {
         loadVerificationKey(N_LOC, OMEGA_INVERSE_LOC);
         // @note - The order of the checks in this implementation differs from the paper to save gas.
         uint256 requiredPublicInputCount;

--- a/src/ultra/BaseUltraVerifier.sol
+++ b/src/ultra/BaseUltraVerifier.sol
@@ -309,7 +309,7 @@ abstract contract BaseUltraVerifier {
      * @param _publicInputs - An array of the public inputs
      * @return True if proof is valid, reverts otherwise
      */
-    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external returns (bool) {
+    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external view returns (bool) {
         loadVerificationKey(N_LOC, OMEGA_INVERSE_LOC);
 
         uint256 requiredPublicInputCount;


### PR DESCRIPTION
According to linters in the Remix IDE, the verify function should be restricted to a view. This also makes the function easier to consume via Ethers.js, etc.