### PR TITLE
Changed verify visibility from external to public

### DIFF
--- a/src/standard/BaseStandardVerifier.sol
+++ b/src/standard/BaseStandardVerifier.sol
@@ -155,7 +155,7 @@ abstract contract BaseStandardVerifier {
      * @param _publicInputs - An array of the public inputs
      * @return True if proof is valid, reverts otherwise
      */
-    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external view returns (bool) {
+    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) public view returns (bool) {
         loadVerificationKey(N_LOC, OMEGA_INVERSE_LOC);
         // @note - The order of the checks in this implementation differs from the paper to save gas.
         uint256 requiredPublicInputCount;

--- a/src/ultra/BaseUltraVerifier.sol
+++ b/src/ultra/BaseUltraVerifier.sol
@@ -302,7 +302,7 @@ abstract contract BaseUltraVerifier {
      * @param _publicInputs - An array of the public inputs
      * @return True if proof is valid, reverts otherwise
      */
-    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external view returns (bool) {
+    function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) public view returns (bool) {
         loadVerificationKey(N_LOC, OMEGA_INVERSE_LOC);
 
         uint256 requiredPublicInputCount;


### PR DESCRIPTION
Made this change only on `BaseStandardVerifier.sol` and `BaseUltraVerifier.sol` solidity files. The `IVerifier.sol` interfaces should continue `external` as is expected from interfaces.